### PR TITLE
DBに送信されたデータが登録されるようにする

### DIFF
--- a/api/cruds/submit.py
+++ b/api/cruds/submit.py
@@ -1,0 +1,13 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import api.models.submit as submit_model
+import api.schemas.submit as submit_schema
+
+async def create_submit(
+  db: AsyncSession, submit_src: submit_schema.SubmitSrc
+) ->  submit_model.Submit:
+  submit = submit_model.Submit(**submit_src.dict())
+  db.add(submit)
+  await db.commit()
+  await db.refresh(submit)
+  return submit

--- a/api/models/submit.py
+++ b/api/models/submit.py
@@ -21,4 +21,4 @@ class Done(Base):
     id = Column(Integer, ForeignKey("submits.id"), primary_key=True)
     message = Column(String(1024))
 
-    task = relationship("Task", back_populates="done")
+    submit = relationship("Submit", back_populates="done")

--- a/api/routers/submit.py
+++ b/api/routers/submit.py
@@ -1,7 +1,10 @@
 from typing import List
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import api.schemas.submit as submit_schema
+import api.cruds.submit as submit_crud
+from api.db import get_db
 
 router = APIRouter()
 
@@ -10,7 +13,7 @@ router = APIRouter()
 async def list_src():
     return [submit_schema.Submit(id=1)]
 
-@router.post("/submits", response_model=submit_schema.SubmitSrcRsponse)
-async def submit_src(submit_src_body: submit_schema.SubmitSrc):
-    return submit_schema.SubmitSrcRsponse(id=1,password="aiueo", **submit_src_body.dict())
+@router.post("/submits", response_model=submit_schema.SubmitSrcResponse)
+async def create_submit(submit_src_body: submit_schema.SubmitSrc, db: AsyncSession = Depends(get_db)):
+    return await submit_crud.create_submit(db, submit_src_body)
 

--- a/api/schemas/submit.py
+++ b/api/schemas/submit.py
@@ -5,14 +5,12 @@ from pydantic import BaseModel, Field
 
 
 class SubmitBase(BaseModel):
-    src: Optional[str] = Field(None, example="#include <stdio.h>")
-    error: Optional[str] = Field(None, example="分かりません")
-
+  src: Optional[str] = Field(None, example="#include <stdio.h>")
+  error: Optional[str] = Field(None, example="分かりません")
 class SubmitSrc(SubmitBase):
-  pass
-class SubmitSrcRsponse(SubmitSrc):
+  password: Optional[str] = Field(None, example="test1234")
+class SubmitSrcResponse(SubmitSrc):
   id: int
-  password: Optional[str] = Field(None, example="aiueo")
 
   class Config:
     orm_mode = True


### PR DESCRIPTION
<!-- resolve #1 のようにresolveの後ろに関連するissueの番号を記載する -->  
resolve #8 

## 対応内容  

- [x] crud.create_submitの作成
- [x] スキーマを調整して、リクエストにpasswordを含めフロント側で自動生成するようにする
- [x] DBモデルのタイポを修正 

## 画面UI
## 動作確認

- swaggerUIでDBにデータが登録されることを確認

## その他